### PR TITLE
Bower package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-	"name": "crumpet-bower-test",
+	"name": "crumpet",
 	"version": "0.0.1",
 	"keywords": [
 		"simple",
@@ -10,8 +10,7 @@
 	],
 	"homepage": "http://suitedpixel.com/crumpet/",
 	"authors": [
-		"Adam Marsden <https://github.com/AdamMarsBar>",
-		"sviens <https://github.com/sviens>"
+		"Adam Marsden <https://github.com/AdamMarsBar>"
 	],
 	"description": "Crumpet is a deliciously simple SASS/SCSS responsive framework that keeps your HTML clean & stays out of your way.",
 	"main": [


### PR DESCRIPTION
I thought your delicious framework would benefit from being registered as a `bower install <package>`. 

I registered a test version (`bower install crumpet-bower-test`), that I'll [request be unregistered](https://github.com/bower/bower/issues/120) if you dig the package addition.

If you're not cool with that, would you mind if I forked and packaged it myself (I'll keep your attribution)?

Thanks!
